### PR TITLE
Update Google Analytics tags from UA to GA4

### DIFF
--- a/roles/setup-beta/defaults/main/main.yml
+++ b/roles/setup-beta/defaults/main/main.yml
@@ -15,4 +15,4 @@ beta_recaptcha_private: "{{ vault_beta_recaptcha_private }}"
 beta_facebook_app_id: 977909275682435
 beta_facebook_app_secret: "{{ vault_beta_facebook_app_secret }}"
 
-beta_google_analytics_id: UA-141756852-2
+beta_google_analytics_id: G-C4NJFCCE0S

--- a/roles/setup-smr/defaults/main/main.yml
+++ b/roles/setup-smr/defaults/main/main.yml
@@ -14,7 +14,7 @@ smr_recaptcha_private: "{{ vault_smr_recaptcha_private }}"
 smr_facebook_app_id: 135977559774648
 smr_facebook_app_secret: "{{ vault_smr_facebook_app_secret }}"
 
-smr_google_analytics_id: UA-141756852-1
+smr_google_analytics_id: G-NTP0FRQX5H
 
 smr_s3_access_key: "{{ vault_smr_s3_access_key }}"
 smr_s3_secret_key: "{{ vault_smr_s3_secret_key }}"


### PR DESCRIPTION
Google Analytics 4 (GA4) is replacing Universal Analytics (UA). The
only thing that needs to change is the ID.

The configuration change technically doesn't need to take place until
2023-07-01 (the date when UA stops processing new page hits), since
the new GA4 properties were automatically linked to UA properties by
the upgrade wizard.