### PR TITLE
Replace jvn.unattended-upgrades with fork

### DIFF
--- a/einstein.yml
+++ b/einstein.yml
@@ -2,7 +2,7 @@
 - hosts: all
   remote_user: root
   roles:
-    - role: jnv.unattended-upgrades
+    - role: hifis.unattended_upgrades
       unattended_origins_patterns:
         - o=${distro_id},a=${distro_codename}
         - o=${distro_id},a=${distro_codename}-updates

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 - src: geerlingguy.docker
   version: 4.1.1
 
-- src: jnv.unattended-upgrades
-  version: v1.11.0
+- src: hifis.unattended_upgrades
+  version: v1.12.2


### PR DESCRIPTION
The original version of this role has been deprecated in favor of one of its forks.

See https://github.com/jnv/ansible-role-unattended-upgrades/issues/98.