### PR TITLE
Make ansible-lint strict

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,4 +1,5 @@
 ---
+strict: true
 skip_list:
   # https://github.com/ansible/ansible-lint/issues/2050
   - fqcn-builtins

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansible
 ansible-core >= 2.12
-ansible-lint >= 6.4.0
+ansible-lint >= 6.8.3


### PR DESCRIPTION
This option was added to the ansible-lint config file in v6.8.3, so we need to bump the minimum requirement.