### PR TITLE
Update ansible-lint to 6.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,9 @@ jobs:
       - name: Checkout the source code
         uses: actions/checkout@v3
 
+      - name: Create ansible secrets file
+        run: |
+            echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > ${{ github.workspace }}/.ansible_secret
+
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6.15.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6.11.0
+        uses: ansible-community/ansible-lint-action@v6.15.0

--- a/einstein.yml
+++ b/einstein.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Play for provisioning the SMR server
+  hosts: all
   remote_user: root
   roles:
     - role: hifis.unattended_upgrades

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansible
 ansible-core >= 2.12
-ansible-lint >= 6.8.3
+ansible-lint >= 6.15.0

--- a/roles/nagios/tasks/main.yml
+++ b/roles/nagios/tasks/main.yml
@@ -34,4 +34,4 @@
   get_url:
     url: https://raw.githubusercontent.com/justintime/nagios-plugins/master/check_mem/check_mem.pl
     dest: /usr/lib/nagios/plugins/check_mem.pl
-    mode: 0755
+    mode: "0755"

--- a/roles/smr_live/tasks/main.yml
+++ b/roles/smr_live/tasks/main.yml
@@ -9,7 +9,7 @@
   file:
     path: "{{ smr_home_dir }}/traefik/acme.json"
     state: touch
-    mode: 0600
+    mode: "0600"
 
 - name: Generate MySql password
   set_fact:

--- a/roles/smr_webboard/tasks/main.yml
+++ b/roles/smr_webboard/tasks/main.yml
@@ -16,7 +16,7 @@
   file:
     path: "{{ webboard_home_dir }}/config.php"
     group: www-data
-    mode: 0640
+    mode: "0640"
 
 - name: Start webboard service and dependencies # noqa: no-changed-when
   command: docker compose up --detach webboard

--- a/roles/smr_wiki/tasks/main.yml
+++ b/roles/smr_wiki/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Restrict .pem file permissions for wiki.js
   file:
     path: "{{ wiki_home_dir }}/wiki-data.pem"
-    mode: 0600
+    mode: "0600"
 
 - name: Start wiki service and dependencies # noqa: no-changed-when
   command: docker compose up --detach wiki


### PR DESCRIPTION
* Update ansible-lint to 6.15.0
* Fix some ansible-lint warnings
* Add the ansible secrets file to the CI workflow

Created from a branch in this repository instead of my fork so that the repo secrets can be used properly.

Closes #21 (superseded)
Closes #20 (superseded)