### PR TITLE
requirements.yml: add community collections

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -20,7 +20,7 @@ def main():
 
     # Install the roles that we're using from the Ansible Galaxy.
     force = '--force' if args.force else ''
-    cmd = "ansible-galaxy install -p roles -r requirements.yml {}".format(force)
+    cmd = "ansible-galaxy role install -p roles -r requirements.yml {}".format(force)
     print("Running: {}".format(cmd))
     sp.check_call(shlex.split(cmd))
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,12 @@
 ---
-# Roles to install from Ansible Galaxy
+collections:
 
-- src: geerlingguy.docker
-  version: 6.0.4
+  - community.general
 
-- src: hifis.unattended_upgrades
-  version: v2.0.1
+roles:
+
+  - src: geerlingguy.docker
+    version: 6.0.4
+
+  - src: hifis.unattended_upgrades
+    version: v2.0.1


### PR DESCRIPTION
Third-party collections need to be specified in the requirements.yml file for them to recognized by ansible-lint (and to correctly enumerate our dependencies, though `community.general` is likely going to be present in any ansible installation).

Fixes the following ansible-lint warning:

> WARNING  Unable to load module community.general.timezone at roles/system_config/tasks/main.yml:46 for options validation
> WARNING  Unable to resolve FQCN for module community.general.timezone

We also add the `role` subcommand to the `ansible-galaxy` command in deploy.py to avoid an informational warning about not installing the collections in the requirements.yml file.