### PR TITLE
Remove dockerize repo

### DIFF
--- a/roles/smr_beta/defaults/main/main.yml
+++ b/roles/smr_beta/defaults/main/main.yml
@@ -2,7 +2,6 @@
 # where smr beta repo will be installed
 beta_home_dir: /root/beta
 
-beta_mysql_host: beta-mysql
 beta_mysql_user: smr
 beta_mysql_database: smr_live
 beta_mysql_root_password: "{{ vault_beta_mysql_root_password }}"

--- a/roles/smr_beta/files/.env
+++ b/roles/smr_beta/files/.env
@@ -1,8 +1,9 @@
 # Environment file for docker-compose
-SMR_HOST=beta-game
-MYSQL_HOST={{ beta_mysql_host }}
 MYSQL_USER={{ beta_mysql_user }}
 MYSQL_DATABASE={{ beta_mysql_database }}
 MYSQL_ROOT_PASSWORD={{ beta_mysql_root_password }}
 MYSQL_PASSWORD={{ beta_mysql_password }}
-SMR_RULE=Host(`beta.smrealms.de`)
+
+SMR_HOST_RULE=Host(`beta.smrealms.de`)
+SMR_BASE_IMG_SERVICE=smr-base-img-local
+SMR_BASE_SRC_SERVICE=smr-base-src-mount

--- a/roles/smr_beta/files/.my.cnf
+++ b/roles/smr_beta/files/.my.cnf
@@ -1,0 +1,5 @@
+# Allow passwordless login to mysql via commandline
+[client]
+host=localhost
+user=root
+password={{ beta_mysql_root_password }}

--- a/roles/smr_beta/files/config/config.specific.php
+++ b/roles/smr_beta/files/config/config.specific.php
@@ -34,8 +34,6 @@ const CONTACT_FORM_CC_ADDRESSES = [
 	'daniel.hemberger@gmail.com',
 ];
 
-const SMTP_HOSTNAME = 'smtp';
-
 const HISTORY_DATABASES = [];
 
 //-------------------

--- a/roles/smr_beta/tasks/main.yml
+++ b/roles/smr_beta/tasks/main.yml
@@ -9,7 +9,10 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ beta_home_dir }}/{{ item.path }}"
-    mode: u=rw,g=r,o=r
+    mode: >-
+      {{ 'u=rw,g=r,o=r'
+         if item.path == 'config/config.specific.php'
+         else 'u=rw,g=,o=' }}
   with_community.general.filetree: "{{ 'files/' }}"
   when: item.state == 'file'
 

--- a/roles/smr_live/defaults/main/main.yml
+++ b/roles/smr_live/defaults/main/main.yml
@@ -1,8 +1,7 @@
 ---
 # where smr will be installed
-smr_home_dir: /root/dockerize
+smr_home_dir: /root/live
 
-smr_mysql_host: smr-mysql
 smr_mysql_user: smr
 smr_mysql_database: smr_live
 smr_mysql_root_password: "{{ vault_smr_mysql_root_password }}"

--- a/roles/smr_live/files/.env
+++ b/roles/smr_live/files/.env
@@ -1,9 +1,13 @@
 # Environment file for docker-compose
 MYSQL_ROOT_PASSWORD={{ smr_mysql_root_password }}
 MYSQL_PASSWORD={{ smr_mysql_password }}
-MYSQL_HOST={{ smr_mysql_host }}
 MYSQL_USER={{ smr_mysql_user }}
 MYSQL_DATABASE={{ smr_mysql_database }}
+
+POSTFIX_HOSTNAME=einstein.fem.tu-ilmenau.de
+SMR_HOST_RULE=(Host(`www.smrealms.de`) || Host(`smrealms.de`))
+SMR_BASE_IMG_SERVICE=smr-base-img-live
+SMR_BASE_SRC_SERVICE=smr-base-src-build
 
 S3_ACCESS_KEY={{ smr_s3_access_key }}
 S3_SECRET_KEY={{ smr_s3_secret_key }}

--- a/roles/smr_live/files/config/config.specific.php
+++ b/roles/smr_live/files/config/config.specific.php
@@ -35,11 +35,6 @@ const CONTACT_FORM_CC_ADDRESSES = [
 	'daniel.hemberger@gmail.com',
 ];
 
-# Refer to the smtp container name in the dockerize (live) repo. This name is
-# unique, unlike the service name ("smtp"), which is the same in both beta and
-# live. This ensures we only ever connect to the live smtp service.
-const SMTP_HOSTNAME = 'smr-smtp';
-
 const HISTORY_DATABASES = [
 	'smr_classic_history' => 'old_account_id',
 	'smr_12_history' => 'old_account_id2',

--- a/roles/smr_live/tasks/main.yml
+++ b/roles/smr_live/tasks/main.yml
@@ -1,9 +1,16 @@
 ---
-- name: Checkout git repository 'smrealms/dockerize'
+- name: Checkout git repository 'smrealms/smr'
   git:
-    repo: https://github.com/smrealms/dockerize.git
+    repo: https://github.com/smrealms/smr.git
     dest: "{{ smr_home_dir }}"
-    version: main
+    version: live
+
+# This is needed so that we don't need verbose -f arguments to docker-compose
+- name: Set up the docker-compose live overrides
+  file:
+    src: "{{ smr_home_dir }}/live/docker-compose.override.yml"
+    dest: "{{ smr_home_dir }}/docker-compose.override.yml"
+    state: link
 
 - name: Create acme.json for traefik
   file:
@@ -27,7 +34,10 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ smr_home_dir }}/{{ item.path }}"
-    mode: u=rw,g=r,o=r
+    mode: >-
+      {{ 'u=rw,g=r,o=r'
+         if item.path == 'config/config.specific.php'
+         else 'u=rw,g=,o=' }}
   with_community.general.filetree: "{{ 'files/' }}"
   when: item.state == 'file'
 
@@ -45,7 +55,7 @@
 
 - name: Fix file permissions for player images
   file:
-    path: "{{ smr_home_dir }}/player-upload"
+    path: "{{ smr_home_dir }}/vol_upload"
     recurse: true
     owner: www-data
     group: www-data
@@ -63,31 +73,37 @@
   command: ./restore_smr_live.sh
   args:
     chdir: "{{ smr_home_dir }}/backup"
-    creates: "{{ smr_home_dir }}/data/db/smr_live/game.MYD"
+    creates: "{{ smr_home_dir }}/vol_db/smr_live/game.MYD"
 
 - name: Restore database 'smr_12_history'
   command: ./restore_smr_archive.sh smr_12_history.sql.bz2
   args:
     chdir: "{{ smr_home_dir }}/backup"
-    creates: "{{ smr_home_dir }}/data/db/smr_12_history/game.MYD"
+    creates: "{{ smr_home_dir }}/vol_db/smr_12_history/game.MYD"
 
 - name: Restore database 'smr_classic_history'
   command: ./restore_smr_archive.sh smr_classic_history.sql.bz2
   args:
     chdir: "{{ smr_home_dir }}/backup"
-    creates: "{{ smr_home_dir }}/data/db/smr_classic_history/game.MYD"
+    creates: "{{ smr_home_dir }}/vol_db/smr_classic_history/game.MYD"
 
 - name: Update password to MySql user 'smr' for when changed on redeploy # noqa: no-changed-when
-  command: docker exec -i {{ smr_mysql_host }} mysql -e "ALTER USER smr IDENTIFIED BY '{{ smr_mysql_password }}';"
+  command: docker compose exec -T mysql mysql -e "ALTER USER {{ smr_mysql_user }} IDENTIFIED BY '{{ smr_mysql_password }}';"
+  args:
+    chdir: "{{ smr_home_dir }}"
 
 - name: Grant permissions to smr_12_history # noqa: no-changed-when
-  command: docker exec -i {{ smr_mysql_host }} mysql -e "GRANT SELECT ON smr_12_history.* TO smr;"
+  command: docker compose exec mysql mysql -e "GRANT SELECT ON smr_12_history.* TO {{ smr_mysql_user }};"
+  args:
+    chdir: "{{ smr_home_dir }}"
 
 - name: Grant permissions to smr_classic_history # noqa: no-changed-when
-  command: docker exec -i {{ smr_mysql_host }} mysql -e "GRANT SELECT ON smr_classic_history.* TO smr;"
+  command: docker compose exec -T mysql mysql -e "GRANT SELECT ON smr_classic_history.* TO {{ smr_mysql_user }};"
+  args:
+    chdir: "{{ smr_home_dir }}"
 
 - name: Start SMR and related services # noqa: no-changed-when
-  command: docker compose up --detach smr discord irc
+  command: docker compose up --detach smr discord irc traefik
   args:
     chdir: "{{ smr_home_dir }}"
 


### PR DESCRIPTION
This implements the changes required by smrealms/smr#2152.

* New required variables in the `.env` files.
* All game mysql instances are expected to have a `.my.cnf` file.
* SMTP and MySQL hostnames are now hard-coded to the service names.
* Role files are now copied with only owner permissions since they container sensitive passwords (except for `config.specific.php`, which needs to be world-readable since apache does not run as root).
* All docker commands now use `compose` so that we can use the compose service names (the container names are now all dynamic).