### PR TITLE
requirements.yml: update geerlingguy.docker from 6.1.0 to 7.5.5

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,7 @@ collections:
 roles:
 
   - src: geerlingguy.docker
-    version: 6.1.0
+    version: 7.5.5
 
   - src: hifis.unattended_upgrades
     version: v3.0.0


### PR DESCRIPTION
I don't think this requires any changes to the role options, but this has not been thoroughly tested.